### PR TITLE
Implement connection cursor mapper

### DIFF
--- a/src/main/java/com/bretpatterson/schemagen/graphql/typemappers/relay/ConnectionCursorMapper.java
+++ b/src/main/java/com/bretpatterson/schemagen/graphql/typemappers/relay/ConnectionCursorMapper.java
@@ -1,0 +1,35 @@
+package com.bretpatterson.schemagen.graphql.typemappers.relay;
+
+import com.bretpatterson.schemagen.graphql.IGraphQLObjectMapper;
+import com.bretpatterson.schemagen.graphql.annotations.GraphQLTypeMapper;
+import com.bretpatterson.schemagen.graphql.relay.ConnectionCursor;
+import com.bretpatterson.schemagen.graphql.typemappers.IGraphQLTypeMapper;
+import graphql.Scalars;
+import graphql.schema.GraphQLInputType;
+import graphql.schema.GraphQLOutputType;
+
+import java.lang.reflect.Type;
+
+/**
+ * Specification Compliant ConnectionCursor mapper
+ *
+ * @see <a href="https://facebook.github.io/relay/graphql/connections.htm">Connection Specification</a>
+ */
+@GraphQLTypeMapper(type = ConnectionCursor.class)
+public class ConnectionCursorMapper implements IGraphQLTypeMapper {
+
+    @Override
+    public boolean handlesType(IGraphQLObjectMapper graphQLObjectMapper, Type type) {
+        return ConnectionCursor.class.isAssignableFrom(graphQLObjectMapper.getClassFromType(type));
+    }
+
+    @Override
+    public GraphQLOutputType getOutputType(IGraphQLObjectMapper graphQLObjectMapper, Type type) {
+        return Scalars.GraphQLString;
+    }
+
+    @Override
+    public GraphQLInputType getInputType(IGraphQLObjectMapper graphQLObjectMapper, Type type) {
+        return Scalars.GraphQLString;
+    }
+}

--- a/src/test/java/com/bretpatterson/schemagen/graphql/impl/GraphQLObjectMapperTest.java
+++ b/src/test/java/com/bretpatterson/schemagen/graphql/impl/GraphQLObjectMapperTest.java
@@ -142,9 +142,7 @@ public class GraphQLObjectMapperTest {
 		assertNotNull(edgeObject.getFieldDefinition("node"));
 		assertNotNull(edgeObject.getFieldDefinition("cursor"));
 		assertEquals(Scalars.GraphQLString, edgeObject.getFieldDefinition("node").getType());
-		assertEquals(GraphQLObjectType.class, edgeObject.getFieldDefinition("cursor").getType().getClass());
-		assertNotNull(((GraphQLObjectType) edgeObject.getFieldDefinition("cursor").getType()).getFieldDefinition("value"));
-		assertEquals(Scalars.GraphQLString, ((GraphQLObjectType) edgeObject.getFieldDefinition("cursor").getType()).getFieldDefinition("value").getType());
+		assertEquals(Scalars.GraphQLString, edgeObject.getFieldDefinition("cursor").getType());
 	}
 
 	private class InnerGeneric<R, S> {

--- a/src/test/java/com/bretpatterson/schemagen/graphql/relay/RelayTest.java
+++ b/src/test/java/com/bretpatterson/schemagen/graphql/relay/RelayTest.java
@@ -142,8 +142,8 @@ public class RelayTest {
 	private RelayConnection<GameDTO> findGames(int first) throws IOException {
 
 		ExecutionResult result = new GraphQL(schema).execute(String
-				.format("{ Queries { games(first:%d) { edges { node {id, name}, cursor {value} } , pageInfo {hasPreviousPage, hasNextPage} } } }", first));
-		assertEquals(0, result.getErrors().size());
+				.format("{ Queries { games(first:%d) { edges { node {id, name}, cursor } , pageInfo {hasPreviousPage, hasNextPage} } } }", first));
+		assertEquals(result.getErrors().toString(), 0, result.getErrors().size());
 
 		return deserialize(objectMapper.writeValueAsString(getQueryResults(result, "games")), new TypeReference<RelayConnection<GameDTO>>() {
 		});

--- a/src/test/java/com/bretpatterson/schemagen/graphql/typemappers/relay/ConnectionCursorMapperTest.java
+++ b/src/test/java/com/bretpatterson/schemagen/graphql/typemappers/relay/ConnectionCursorMapperTest.java
@@ -1,0 +1,79 @@
+package com.bretpatterson.schemagen.graphql.typemappers.relay;
+
+import com.bretpatterson.schemagen.graphql.IGraphQLObjectMapper;
+import com.bretpatterson.schemagen.graphql.relay.ConnectionCursor;
+import graphql.Scalars;
+import graphql.schema.GraphQLNonNull;
+import graphql.schema.GraphQLOutputType;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.lang.reflect.Type;
+
+import static org.junit.Assert.*;
+import static org.mockito.BDDMockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ConnectionCursorMapperTest {
+
+    @Mock
+    private IGraphQLObjectMapper mockMapper;
+
+    @Test
+    public void test_handlesType_ConnectionCursor_true() throws Exception {
+        // given
+        Type type = ConnectionCursor.class;
+        willReturn(ConnectionCursor.class).given(mockMapper).getClassFromType(type);
+        ConnectionCursorMapper cut = createCut();
+
+        // when
+        boolean result = cut.handlesType(mockMapper, type);
+
+        // then
+        assertTrue(result);
+    }
+
+    @Test
+    public void test_handlesType_Other_false() throws Exception {
+        // given
+        Type type = Object.class;
+        willReturn(Object.class).given(mockMapper).getClassFromType(type);
+        ConnectionCursorMapper cut = createCut();
+
+        // when
+        boolean result = cut.handlesType(mockMapper, type);
+
+        // then
+        assertFalse(result);
+    }
+
+    @Test
+    public void test_getOutputType() throws Exception {
+        // given
+        ConnectionCursorMapper cut = createCut();
+
+        // when
+        GraphQLOutputType result = cut.getOutputType(null, null);
+
+        // then
+        assertEquals(result, Scalars.GraphQLString);
+    }
+
+    @Test
+    public void test_getInputType() throws Exception {
+        // given
+        ConnectionCursorMapper cut = createCut();
+
+        // when
+        GraphQLOutputType result = cut.getOutputType(null, null);
+
+        // then
+        assertEquals(result, Scalars.GraphQLString);
+    }
+
+    private ConnectionCursorMapper createCut() {
+        return new ConnectionCursorMapper();
+    }
+}


### PR DESCRIPTION
The default implementation generates a graphQL type that does not match the [spec](https://facebook.github.io/relay/graphql/connections.htm).


Before:
```
            {
              "name": "startCursor",
              "description": null,
              "args": [],
              "type": {
                "kind": "OBJECT",
                "name": "ConnectionCursor",
                "ofType": null
              },
              "isDeprecated": false,
              "deprecationReason": null
            },
...
        {
          "kind": "INPUT_OBJECT",
          "name": "ConnectionCursor_Input",
          "description": null,
          "fields": null,
          "inputFields": [
            {
              "name": "value",
              "description": null,
              "type": {
                "kind": "SCALAR",
                "name": "String",
                "ofType": null
              },
              "defaultValue": null
            }
          ],
          "interfaces": null,
          "enumValues": null,
          "possibleTypes": null
        },
```

After:
```
            {
              "name": "startCursor",
              "description": null,
              "args": [],
              "type": {
                "kind": "NON_NULL",
                "name": null,
                "ofType": {
                  "kind": "SCALAR",
                  "name": "String",
                  "ofType": null
                }
              },
              "isDeprecated": false,
              "deprecationReason": null
            },
```

Ciaran