### PR TITLE
Naming strategy customizations

### DIFF
--- a/src/main/java/com/bretpatterson/schemagen/graphql/ITypeNamingStrategy.java
+++ b/src/main/java/com/bretpatterson/schemagen/graphql/ITypeNamingStrategy.java
@@ -14,4 +14,16 @@ public interface ITypeNamingStrategy {
 	 * @return
 	 */
 	String getTypeName(IGraphQLObjectMapper graphQLObjectMapper, Type type);
+
+	/**
+	 * String to append to GraphQL InputType's
+	 * @return
+	 */
+	String getInputTypePostfix();
+
+	/**
+	 * Delimiter used for separating sections of a type name
+	 * @return
+	 */
+	String getDelimiter();
 }

--- a/src/main/java/com/bretpatterson/schemagen/graphql/impl/FullTypeNamingStrategy.java
+++ b/src/main/java/com/bretpatterson/schemagen/graphql/impl/FullTypeNamingStrategy.java
@@ -15,7 +15,10 @@ public class FullTypeNamingStrategy extends SimpleTypeNamingStrategy {
 		String typeName = super.getTypeName(graphQLObjectMapper, type);
 
 		if (theClass.getPackage() != null) {
-			return String.format("%s_%s", theClass.getPackage().getName().replace(".", "_"), typeName);
+			return String.format("%s%s%s",
+					theClass.getPackage().getName().replace(".", this.getDelimiter()),
+					this.getDelimiter(),
+					typeName);
 		} else {
 			return typeName;
 		}

--- a/src/main/java/com/bretpatterson/schemagen/graphql/impl/GraphQLObjectMapper.java
+++ b/src/main/java/com/bretpatterson/schemagen/graphql/impl/GraphQLObjectMapper.java
@@ -526,7 +526,15 @@ public class GraphQLObjectMapper implements IGraphQLObjectMapper, TypeResolver {
 			return (GraphQLInputType) outputType;
 		} else if (outputType instanceof GraphQLObjectType) {
 			GraphQLObjectType objectType = (GraphQLObjectType) outputType;
-			GraphQLInputObjectType.Builder rv = GraphQLInputObjectType.newInputObject().name(objectType.getName() + "_Input");
+
+			final String inputTypeName;
+
+			inputTypeName = String.format("%s%s%s",
+					objectType.getName(),
+					this.getTypeNamingStrategy().getDelimiter(),
+					this.getTypeNamingStrategy().getInputTypePostfix());
+
+			GraphQLInputObjectType.Builder rv = GraphQLInputObjectType.newInputObject().name(inputTypeName);
 
 			rv.description(((GraphQLObjectType) outputType).getDescription());
 			for (GraphQLFieldDefinition field : objectType.getFieldDefinitions()) {

--- a/src/main/java/com/bretpatterson/schemagen/graphql/impl/RelayTypeNamingStrategy.java
+++ b/src/main/java/com/bretpatterson/schemagen/graphql/impl/RelayTypeNamingStrategy.java
@@ -11,40 +11,58 @@ import java.lang.reflect.Type;
  */
 public class RelayTypeNamingStrategy extends SimpleTypeNamingStrategy {
 
-	@Override
-	public String getTypeName(IGraphQLObjectMapper graphQLObjectMapper, Type type) {
-		String typeString;
-		Class<?> theClass = graphQLObjectMapper.getClassFromType(type);
+    public RelayTypeNamingStrategy(String delimiter, String inputTypePostfix) {
+        super(delimiter, inputTypePostfix);
+    }
 
-		GraphQLName typeName = theClass.getAnnotation(GraphQLName.class);
-		if (typeName != null) {
-			return typeName.name();
-		}
+    public RelayTypeNamingStrategy() {
+    }
 
-		// start with the class name
-		typeString = theClass.getSimpleName();
-		// for parameterized types append the parameter types to build unique type
-		if (type instanceof ParameterizedType) {
-			ParameterizedType pType = (ParameterizedType) type;
+    @Override
+    public String getTypeName(IGraphQLObjectMapper graphQLObjectMapper, Type type) {
+        String typeString;
+        Class<?> theClass = graphQLObjectMapper.getClassFromType(type);
 
-			// relay has special handling for types that end with Connection so we need to
-			// preserve the types trailing connection in this scenario
-			if (typeString.toLowerCase().endsWith("connection")) {
-				// we only want the part of the typeString without the trailing connection
-				String prefix = typeString.substring(0, typeString.toLowerCase().lastIndexOf("connection"));
-				String suffix = typeString.substring(typeString.toLowerCase().lastIndexOf("connection"), typeString.length());
-				// RelayConnection<String> --> Relay_String_Connection
-				if (prefix.length() >0) {
-					typeString = String.format("%s_%s_%s", prefix, getParametersTypeString(graphQLObjectMapper, pType), suffix);
-				} else {
-					typeString = String.format("%s_%s", getParametersTypeString(graphQLObjectMapper, pType), suffix);
+        GraphQLName typeName = theClass.getAnnotation(GraphQLName.class);
+        if (typeName != null) {
+            return typeName.name();
+        }
 
-				}
-			} else {
-				typeString = String.format("%s_%s", typeString, getParametersTypeString(graphQLObjectMapper, pType));
-			}
-		}
+        // start with the class name
+        typeString = theClass.getSimpleName();
+        // for parameterized types append the parameter types to build unique type
+        if (type instanceof ParameterizedType) {
+            ParameterizedType pType = (ParameterizedType) type;
 
-		return typeString;
-	}
+            // relay has special handling for types that end with Connection so we need to
+            // preserve the types trailing connection in this scenario
+            if (typeString.toLowerCase().endsWith("connection")) {
+                // we only want the part of the typeString without the trailing connection
+                String prefix = typeString.substring(0, typeString.toLowerCase().lastIndexOf("connection"));
+                String suffix = typeString.substring(typeString.toLowerCase().lastIndexOf("connection"), typeString.length());
+                // RelayConnection<String> --> Relay_String_Connection
+                if (prefix.length() > 0) {
+                    typeString = String.format("%s%s%s%s%s",
+                            prefix,
+                            this.getDelimiter(),
+                            getParametersTypeString(graphQLObjectMapper, pType),
+                            this.getDelimiter(),
+                            suffix);
+                } else {
+                    typeString = String.format("%s%s%s",
+                            getParametersTypeString(graphQLObjectMapper, pType),
+                            this.getDelimiter(),
+                            suffix);
+
+                }
+            } else {
+                typeString = String.format("%s%s%s",
+                        typeString,
+                        this.getDelimiter(),
+                        getParametersTypeString(graphQLObjectMapper, pType));
+            }
+        }
+
+        return typeString;
+    }
 }

--- a/src/main/java/com/bretpatterson/schemagen/graphql/impl/SimpleTypeNamingStrategy.java
+++ b/src/main/java/com/bretpatterson/schemagen/graphql/impl/SimpleTypeNamingStrategy.java
@@ -3,6 +3,7 @@ package com.bretpatterson.schemagen.graphql.impl;
 import com.bretpatterson.schemagen.graphql.IGraphQLObjectMapper;
 import com.bretpatterson.schemagen.graphql.ITypeNamingStrategy;
 import com.bretpatterson.schemagen.graphql.annotations.GraphQLName;
+import com.google.common.base.Preconditions;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
@@ -12,42 +13,68 @@ import java.lang.reflect.Type;
  */
 public class SimpleTypeNamingStrategy implements ITypeNamingStrategy {
 
-	@Override
-	public String getTypeName(IGraphQLObjectMapper graphQLObjectMapper, Type type) {
-		String typeString;
-		Class<?> theClass = graphQLObjectMapper.getClassFromType(type);
+    private final String delimiter;
+    private final String inputTypePostfix;
 
-		GraphQLName typeName = theClass.getAnnotation(GraphQLName.class);
-		if (typeName != null) {
-			return typeName.name();
-		}
+    public SimpleTypeNamingStrategy(String delimiter, String inputTypePostfix) {
+        Preconditions.checkNotNull(delimiter, "Delimiter cannot be null.");
+        Preconditions.checkNotNull(inputTypePostfix, "InputType Postfix cannot be null.");
+        this.delimiter = delimiter;
+        this.inputTypePostfix = inputTypePostfix;
+    }
 
-		// start with the class name
-		typeString = theClass.getSimpleName();
+    public SimpleTypeNamingStrategy() {
+        this("_", "Input");
+    }
 
-		// for parameterized types append the parameter types to build unique type
-		if (type instanceof ParameterizedType) {
-			ParameterizedType pType = (ParameterizedType) type;
+    @Override
+    public String getTypeName(IGraphQLObjectMapper graphQLObjectMapper, Type type) {
+        String typeString;
+        Class<?> theClass = graphQLObjectMapper.getClassFromType(type);
 
-			typeString += "_"+getParametersTypeString(graphQLObjectMapper, pType);
-		}
+        GraphQLName typeName = theClass.getAnnotation(GraphQLName.class);
+        if (typeName != null) {
+            return typeName.name();
+        }
 
-		return typeString;
-	}
+        // start with the class name
+        typeString = theClass.getSimpleName();
 
-	String getParametersTypeString(IGraphQLObjectMapper graphQLObjectMapper, ParameterizedType type) {
-		String parametersTypeString = "";
-		Type[] subTypes = type.getActualTypeArguments();
-		for (int i=0; i< subTypes.length; i++) {
-			if (parametersTypeString.length() != 0) {
-				parametersTypeString += "_";
-			}
-			parametersTypeString += graphQLObjectMapper.getClassFromType(subTypes[i]).getSimpleName();
-			if (subTypes[i] instanceof ParameterizedType) {
-				parametersTypeString += "_"+getParametersTypeString(graphQLObjectMapper, (ParameterizedType) subTypes[i]);
-			}
-		}
+        // for parameterized types append the parameter types to build unique type
+        if (type instanceof ParameterizedType) {
+            ParameterizedType pType = (ParameterizedType) type;
 
-		return parametersTypeString;
-	}
+            typeString += this.getDelimiter() +
+                    getParametersTypeString(graphQLObjectMapper, pType);
+        }
+
+        return typeString;
+    }
+
+    String getParametersTypeString(IGraphQLObjectMapper graphQLObjectMapper, ParameterizedType type) {
+        String parametersTypeString = "";
+        Type[] subTypes = type.getActualTypeArguments();
+        for (Type subType : subTypes) {
+            if (parametersTypeString.length() != 0) {
+                parametersTypeString += this.getDelimiter();
+            }
+            parametersTypeString += graphQLObjectMapper.getClassFromType(subType).getSimpleName();
+            if (subType instanceof ParameterizedType) {
+                parametersTypeString += this.getDelimiter() +
+                        getParametersTypeString(graphQLObjectMapper, (ParameterizedType) subType);
+            }
+        }
+
+        return parametersTypeString;
+    }
+
+    @Override
+    public String getInputTypePostfix() {
+        return inputTypePostfix;
+    }
+
+    @Override
+    public String getDelimiter() {
+        return delimiter;
+    }
 }

--- a/src/test/java/com/bretpatterson/schemagen/graphql/impl/SimpleTypeNamingStrategyTest.java
+++ b/src/test/java/com/bretpatterson/schemagen/graphql/impl/SimpleTypeNamingStrategyTest.java
@@ -38,4 +38,23 @@ public class SimpleTypeNamingStrategyTest {
 		given(graphQLObjectMapper.getClassFromType(eq(new TypeToken<Connection<String>>(){}.getType()))).willReturn((Class) Connection.class);
 		assertEquals("Connection_String", strategy.getTypeName(graphQLObjectMapper, new TypeToken<Connection<String>>(){}.getType()));
 	}
+
+	@SuppressWarnings({ "unchecked", "serial", "rawtypes" })
+	@Test
+	public void TestConfigureDelimiterAndInputPostfix() {
+		ITypeNamingStrategy strategy = new SimpleTypeNamingStrategy("$", "GraphQLInput");
+
+
+		given(graphQLObjectMapper.getClassFromType(eq(String.class))).willReturn((Class) String.class);
+
+		assertEquals("String", strategy.getTypeName(graphQLObjectMapper, String.class));
+
+		given(graphQLObjectMapper.getClassFromType(eq(new TypeToken<RelayConnection<String>>(){}.getType()))).willReturn((Class) RelayConnection.class);
+		assertEquals("RelayConnection$String", strategy.getTypeName(graphQLObjectMapper, new TypeToken<RelayConnection<String>>(){}.getType()));
+
+		given(graphQLObjectMapper.getClassFromType(eq(new TypeToken<Connection<String>>(){}.getType()))).willReturn((Class) Connection.class);
+		assertEquals("Connection$String", strategy.getTypeName(graphQLObjectMapper, new TypeToken<Connection<String>>(){}.getType()));
+	}
+
+
 }


### PR DESCRIPTION
Changes to allow changing the delimiter used in the naming strategy as well as optionally changing the default GraphQL InputType postfix.

This is mostly so that the resulting schema is more javascript friendly and also so that I can keep my relay input and payload objects more consistently named.

E.g. PersonMutationInput and PersonMutationPayload instead of PersonMutation a PersonMutationPayload.

Ciaran